### PR TITLE
Add OpenSuse-specific conditional

### DIFF
--- a/CVE-2024-3094-checker.sh
+++ b/CVE-2024-3094-checker.sh
@@ -29,18 +29,19 @@ if [ "$PKG_MANAGER" = "zypper" ]; then
     
     echo "See https://news.opensuse.org/2024/03/29/xz-backdoor/"
     badVersion=false
-    if ([[ version =~ "5.6.0"]] || [[version =~ "5.6.1"]]) && ! [[ version =~ "revertto" ]]; then
+    if ([[ version =~ "5.6.0" ]] || [[ version =~ "5.6.1" ]]) && ! [[ version =~ "revertto" ]]; then
         badVersion=true
         echo "It seems you have the affected version installed"
         echo "OpenSuse has released a patched version that avoids this CVE, running zypper to update the xz package..."
         sudo zypper refresh
         sudo zypper update xz
+    else
+        echo "You probably don't have an affected version installed"
     fi
 
-    lsb_release -d | grep "Tumbleweed"
-    if [ $? -eq 0 ] || badVersion; then
+    if [[ $(lsb_release -d) =~ "Tumbleweed" ]] || $badVersion; then
         echo "OpenSuse recommends that users with the affected versions installed (tumbleweed users) reinstall and change any sensitive credentials as they currently don't have a way to detect a breach"
-    else
+    fi
 
     exit 0
 fi

--- a/CVE-2024-3094-checker.sh
+++ b/CVE-2024-3094-checker.sh
@@ -23,6 +23,13 @@ else
     exit 1
 fi
 
+if [ "$PKG_MANAGER" = "zypper" ]; then
+    echo "OpenSuse has released a patched version that avoids this CVE, running zypper to update the xz package..."
+    echo "See https://news.opensuse.org/2024/03/29/xz-backdoor/"
+    sudo zypper update xz
+    exit $?
+fi
+
 # Get xz-utils version
 version=$(dpkg -l | grep "xz-utils" | awk '{print $3}')
 

--- a/CVE-2024-3094-checker.sh
+++ b/CVE-2024-3094-checker.sh
@@ -24,50 +24,48 @@ else
 fi
 
 if [ "$PKG_MANAGER" = "zypper" ]; then
-    versionString=$(zypper info xz | grep "Version")
-    version=${versionString##* }
-    
-    echo "See https://news.opensuse.org/2024/03/29/xz-backdoor/"
-    badVersion=false
-    if ([[ version =~ "5.6.0" ]] || [[ version =~ "5.6.1" ]]) && ! [[ version =~ "revertto" ]]; then
-        badVersion=true
-        echo "It seems you have the affected version installed"
+
+    version=$(rpm -q xz)
+    if [[ $version =~ (5\.6\.(0|1)) && ! $version =~ revertto ]]; then
+        echo "It seems you have a vulnerable version of the xz package installed on your system"
         echo "OpenSuse has released a patched version that avoids this CVE, running zypper to update the xz package..."
         sudo zypper refresh
         sudo zypper update xz
+        if [ $? -eq 0 ]; then
+            echo "xz package updated successfully. Now it is advisable to reboot"
+        else
+            echo "xz package update failed"
+        fi
+        
+        if lsb_release -d | grep -q "Tumbleweed"; then
+            echo "OpenSuse recommends openSUSE Tumbleweed users where SSH is exposed to the internet to make a fresh installation of the system and change credentials, as it’s unknown if the backdoor has been exploited."
+            echo "Due to the sophisticated nature of the backdoor an on-system detection of a breach is likely not possible."
+            echo "Also rotation of any credentials that could have been fetched from the system is highly recommended."
+        fi
     else
-        echo "You probably don't have an affected version installed"
+        echo "Your OpenSuse installation is probably safe."
     fi
-
-    if [[ $(lsb_release -d) =~ "Tumbleweed" ]] || $badVersion; then
-        echo "OpenSuse recommends that users with the affected versions installed (tumbleweed users) reinstall and change any sensitive credentials as they currently don't have a way to detect a breach"
-    fi
-
-    exit 0
-fi
-
-# Get xz-utils version
-version=$(dpkg -l | grep "xz-utils" | awk '{print $3}')
-
-# Check if vulnerable version is installed
-if [[ "$version" == *"5.6.0"* || "$version" == *"5.6.1"* ]]; then
-    echo "Vulnerable version of xz-utils found: $version"
-    read -p "Do you want to attempt installing the stable uncompromised xz-utils 5.4.6 version from source? (y/n): " choice
-    if [[ "$choice" == "y" || "$choice" == "Y" ]]; then
-        echo "Downloading xz-utils 5.4.6 from source..."
-        wget https://github.com/tukaani-project/xz/releases/download/v5.4.6/xz-5.4.6.tar.gz
-        tar -zxvf xz-5.4.6.tar.gz
-        cd xz-5.4.6
-        echo "Configuring xz-utils..."
-        ./configure
-        echo "Compiling xz-utils..."
-        make
-        echo "Installing xz-utils..."
-        sudo make install
-        echo "xz-utils 5.4.6 installed successfully."
+elif [ "$PKG_MANAGER" = "apt-get" ]; then
+    version=$(dpkg -l | grep "xz-utils" | awk '{print $3}')
+    if [[ "$version" == *"5.6.0"* || "$version" == *"5.6.1"* ]]; then
+        echo "Vulnerable version of xz-utils found: $version"
+        read -p "Do you want to attempt installing the stable uncompromised xz-utils 5.4.6 version from source? (y/n): " choice
+        if [[ "$choice" == "y" || "$choice" == "Y" ]]; then
+            echo "Downloading xz-utils 5.4.6 from source..."
+            wget https://github.com/tukaani-project/xz/releases/download/v5.4.6/xz-5.4.6.tar.gz
+            tar -zxvf xz-5.4.6.tar.gz
+            cd xz-5.4.6
+            echo "Configuring xz-utils..."
+            ./configure
+            echo "Compiling xz-utils..."
+            make
+            echo "Installing xz-utils..."
+            sudo make install
+            echo "xz-utils 5.4.6 installed successfully."
+        else
+            echo "You chose not to install the package automatically. Install manually if needed. Exiting."
+        fi
     else
-        echo "You chose not to install the package automatically. Install manually if needed. Exiting."
+        echo "You appear to be safe."
     fi
-else
-    echo "You appear to be safe."
 fi

--- a/CVE-2024-3094-checker.sh
+++ b/CVE-2024-3094-checker.sh
@@ -24,10 +24,25 @@ else
 fi
 
 if [ "$PKG_MANAGER" = "zypper" ]; then
-    echo "OpenSuse has released a patched version that avoids this CVE, running zypper to update the xz package..."
+    versionString=$(zypper info xz | grep "Version")
+    version=${versionString##* }
+    
     echo "See https://news.opensuse.org/2024/03/29/xz-backdoor/"
-    sudo zypper update xz
-    exit $?
+    badVersion=false
+    if ([[ version =~ "5.6.0"]] || [[version =~ "5.6.1"]]) && ! [[ version =~ "revertto" ]]; then
+        badVersion=true
+        echo "It seems you have the affected version installed"
+        echo "OpenSuse has released a patched version that avoids this CVE, running zypper to update the xz package..."
+        sudo zypper refresh
+        sudo zypper update xz
+    fi
+
+    lsb_release -d | grep "Tumbleweed"
+    if [ $? -eq 0 ] || badVersion; then
+        echo "OpenSuse recommends that users with the affected versions installed (tumbleweed users) reinstall and change any sensitive credentials as they currently don't have a way to detect a breach"
+    else
+
+    exit 0
 fi
 
 # Get xz-utils version


### PR DESCRIPTION
OpenSuse has addressed this issue by updating the package. Thus, you can just upgrade the xz package to the 5.6.1revertto5.4 version.

See https://news.opensuse.org/2024/03/29/xz-backdoor/

This pull request adds proper support for OpenSuse